### PR TITLE
fix: correct vite build output directory to match   GitHub Actions deployment path

### DIFF
--- a/frontendWebsite/vite.config.ts
+++ b/frontendWebsite/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig(({ mode }) => {
   return {
     base: '/comp9034FarmSystem/',
     build: {
-      outDir: 'build/dist',
+      outDir: 'dist',
     },
     plugins: [
       react(),


### PR DESCRIPTION
## Summary
  Fix vite build output directory configuration to
  resolve GitHub Actions deployment path mismatch.

  ## Changes Made
  - Modified vite.config.ts output directory from
  'build/dist' to 'dist'
  - Ensures GitHub Actions can locate build artifacts
  at expected path

  ## Impact
  Resolves the remaining GitHub Actions deployment
  failure after TypeScript compilation fix. The SPA
  routing setup step can now find index.html at the
  correct path.