### PR TITLE
fix(backend): resolve WorkSchedule JSON property collision

### DIFF
--- a/backend/src/Models/WorkSchedule.cs
+++ b/backend/src/Models/WorkSchedule.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
 
 namespace COMP9034.Backend.Models
 {
@@ -13,6 +14,7 @@ namespace COMP9034.Backend.Models
         /// (PK) scheduleID: Unique identifier for each scheduled shift
         /// </summary>
         [Key]
+        [JsonPropertyName("scheduleId")]
         public int ScheduleID { get; set; }
 
         /// <summary>
@@ -101,6 +103,7 @@ namespace COMP9034.Backend.Models
         /// Legacy property mapping for backward compatibility
         /// </summary>
         [NotMapped]
+        [JsonIgnore]
         public int ScheduleId
         {
             get => ScheduleID;


### PR DESCRIPTION
Summary
Resolve a System.Text.Json serialization collision in WorkSchedule where ScheduleID and its legacy alias ScheduleId both map to the same JSON name under camelCase. This caused runtime errors like "The JSON property name for '...WorkSchedule.scheduleId' collides with another property" and 409 responses.

Changes Made
- backend/src/Models/WorkSchedule.cs
  - Add [JsonIgnore] to the legacy alias property (ScheduleId) so it is not emitted in JSON.
  - Add [JsonPropertyName("scheduleId")] to the primary key (ScheduleID) to explicitly stabilize the JSON field name.

Key Benefits
- Eliminates JSON name collision under camelCase policy.
- Keeps API contract stable by explicitly emitting scheduleId.
- Unblocks Staff/WorkSchedule related endpoints from serialization failures.

Testing
- [x] GET/POST endpoints interacting with WorkSchedule no longer return serialization errors.
- [x] JSON now contains only one field: scheduleId.

Impact
- Backward compatible for clients expecting scheduleId.
- No behavior changes outside of JSON serialization attributes.

Modules Affected
- backend/

Rollback Plan
- Revert this commit to restore previous WorkSchedule serialization.