### PR TITLE
fix(backend): map Salary.Status to database to avoid NOT NULL insert errors

### DIFF
--- a/backend/src/Models/Salary.cs
+++ b/backend/src/Models/Salary.cs
@@ -159,9 +159,9 @@ namespace COMP9034.Backend.Models
         }
 
         /// <summary>
-        /// Legacy status property for backward compatibility
+        /// status: Payroll status (e.g., Draft, Finalized, Paid)
+        /// Mapped to database column to match schema (NOT NULL)
         /// </summary>
-        [NotMapped]
         public string Status { get; set; } = "Draft";
 
         // Validation methods


### PR DESCRIPTION
Summary
Align the Salary model with the database schema by mapping the Status column (NOT NULL) to the model. Previously, Status was [NotMapped], which risks insert/update failures since the migration creates a required Status column.

Changes Made
- backend/src/Models/Salary.cs
  - Remove [NotMapped] from Status; keep default value 'Draft' so inserts supply a value for the NOT NULL column.

Key Benefits
- Prevents future insert failures due to unmapped NOT NULL column.
- Keeps model and schema consistent.

Testing
- [x] Insert/update Salary entities successfully persists Status.
- [x] Queries include Status as expected.

Impact
- Backward compatible; default Status remains 'Draft'.

Modules Affected
- backend/

Rollback Plan
- Revert this commit to restore previous [NotMapped] behavior (not recommended due to schema).