### PR TITLE
enhancement(frontend): switch date/time locale to en-GB (DD/MM/YY, 24h HH:MM)

### DIFF
--- a/frontendWebsite/src/utils/time.ts
+++ b/frontendWebsite/src/utils/time.ts
@@ -7,8 +7,9 @@ export function parseISODate(dateString: string): Date {
 
 // Format date for display
 export function formatDate(date: Date): string {
-  return date.toLocaleDateString('zh-CN', {
-    year: 'numeric',
+  // Use British English for DD/MM/YY
+  return date.toLocaleDateString('en-GB', {
+    year: '2-digit',
     month: '2-digit',
     day: '2-digit'
   })
@@ -16,25 +17,18 @@ export function formatDate(date: Date): string {
 
 // Format time for display
 export function formatTime(date: Date): string {
-  return date.toLocaleTimeString('zh-CN', {
+  // 24-hour HH:MM (no seconds)
+  return date.toLocaleTimeString('en-GB', {
     hour: '2-digit',
     minute: '2-digit',
-    second: '2-digit',
     hour12: false
   })
 }
 
 // Format datetime for display
 export function formatDateTime(date: Date): string {
-  return date.toLocaleString('zh-CN', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    hour12: false
-  })
+  // Compose to ensure consistent "DD/MM/YY HH:MM" (no comma, no seconds)
+  return `${formatDate(date)} ${formatTime(date)}`
 }
 
 // Format datetime string (accepts string parameter)


### PR DESCRIPTION
Summary
Standardize all timestamps to English DD/MM/YY and 24-hour HH:MM by updating shared time utilities.

Changes Made
- frontendWebsite/src/utils/time.ts
  - formatDate → DD/MM/YY (en-GB, 2-digit year)
  - formatTime → HH:MM (24h, no seconds)
  - formatDateTime → “DD/MM/YY HH:MM” via composition

Affected Components
- AdminLoginHistory, Station, NetworkBadge, AdminStaffs, AdminEvents (all use the shared utilities)
- Roster remains en-US as previously correct per plan

Testing
- [x] AdminLoginHistory timestamps render as DD/MM/YY HH:MM
- [x] Station last event time shows expected format
- [x] NetworkBadge “Last sync” adheres to new format
- [x] AdminStaffs updatedAt renders correctly
- [x] AdminEvents event timestamps render correctly

Impact
- UI-only format change; no API contract change
- Consistent English date/time across app

Modules Affected
- frontendWebsite/

Rollback Plan
- Revert this commit to restore prior zh-CN / seconds-included formatting