### PR TITLE
fix(frontend): ensure Active Staff tab shows only active staff

### DIFF
--- a/frontendWebsite/src/pages/AdminStaffs.tsx
+++ b/frontendWebsite/src/pages/AdminStaffs.tsx
@@ -501,10 +501,11 @@ export function AdminStaffs({ currentUser }: AdminStaffsProps) {
       // Role filter
       const matchesRole = roleFilter === 'all' || staff.role === roleFilter
 
-                    // Status filter (keep the frontend filtering since backend only returns active staff)
-              const matchesStatus = statusFilter === 'all' || 
-                (statusFilter === 'active' && staff.isActive) ||
-                (statusFilter === 'inactive' && !staff.isActive)
+      // Status filter:
+      // - Active tab (0): strictly show only active staff (isActive = true)
+      //   Ignore statusFilter to avoid showing inactive entries on Active tab
+      // - Inactive tab uses a separate dataset (inactiveStaffs), so always allow here
+      const matchesStatus = activeTab === 0 ? staff.isActive : true
 
       return matchesSearch && matchesRole && matchesStatus
     })


### PR DESCRIPTION
Summary
Prevent inactive staff from appearing on the Active Staff tab by enforcing isActive=true on the active tab. The inactive tab continues to use a separate dataset from /api/Staffs/inactive.

Changes Made
- frontendWebsite/src/pages/AdminStaffs.tsx
  - Active tab: strictly filter staff.isActive === true, ignoring statusFilter on this tab.
  - Inactive tab: unchanged; continues to render inactiveStaffs from dedicated API.

Impact
- UI correctness: inactive staff no longer appear on the Active tab marked as "Inactive".
- No backend/API changes required.

Testing
- [x] Delete a staff member → they disappear from Active tab and appear under Inactive tab.
- [x] Switching tabs correctly shows respective datasets.
- [x] Other filters (role, search) still apply within each tab s dataset.

Modules Affected
- frontendWebsite/

Rollback Plan
- Revert this commit to restore previous behavior.