### PR TITLE
enhancement(frontend): lock Status filter to current tab (Active/Inactive)

### DIFF
--- a/frontendWebsite/src/pages/AdminStaffs.tsx
+++ b/frontendWebsite/src/pages/AdminStaffs.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   Box,
   Card,
@@ -585,7 +585,11 @@ export function AdminStaffs({ currentUser }: AdminStaffsProps) {
       <Paper elevation={1} sx={{ mb: 3 }}>
         <Tabs 
           value={activeTab} 
-          onChange={(_, newValue) => setActiveTab(newValue)}
+          onChange={(_, newValue) => {
+            setActiveTab(newValue)
+            // Keep status filter visually consistent with tab
+            setStatusFilter(newValue === 0 ? 'active' : 'inactive')
+          }}
           variant="fullWidth"
           sx={{
             borderBottom: 1,
@@ -655,13 +659,15 @@ export function AdminStaffs({ currentUser }: AdminStaffsProps) {
               <FormControl size="small" fullWidth>
                 <InputLabel>Status</InputLabel>
                 <Select
-                  value={statusFilter}
+                  // Lock status by current tab to avoid confusion
+                  value={activeTab === 0 ? 'active' : 'inactive'}
                   label="Status"
-                  onChange={e => setStatusFilter(e.target.value)}
+                  onChange={() => { /* locked by tab */ }}
+                  disabled
                 >
-                  <MenuItem value="all">All Status</MenuItem>
-                  <MenuItem value="active">Active</MenuItem>
-                  <MenuItem value="inactive">Inactive</MenuItem>
+                  <MenuItem value={activeTab === 0 ? 'active' : 'inactive'}>
+                    {activeTab === 0 ? 'Active' : 'Inactive'}
+                  </MenuItem>
                 </Select>
               </FormControl>
             </Grid>


### PR DESCRIPTION
Summary
Lock the Status dropdown to the current tab to reduce confusion: Active tab always shows Active; Inactive tab always shows Inactive. The dropdown is disabled and follows the selected tab.

Changes Made
- frontendWebsite/src/pages/AdminStaffs.tsx
  - Disable Status Select and bind value to activeTab (Active/Inactive)
  - Update Tabs onChange to set statusFilter for visual consistency

Impact
- Prevents selecting conflicting status values; tab controls the dataset
- Keeps existing behavior where Active tab shows only active staff, and Inactive tab uses separate API data

Testing
- [x] Switching tabs toggles Status display between Active/Inactive
- [x] Inactive staff no longer appear in Active tab
- [x] Filters (search/role) still apply within each tab

Modules Affected
- frontendWebsite/

Rollback Plan
- Revert this commit to restore editable Status filter.