### PR TITLE
chore(ci): enforce no-CJK globally; add optional pre-commit hook

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Confirmation
+- [ ] 中文修改方案已与仓库所有者确认并获得授权
+
+## Summary
+<Describe the problem and the solution in one or two paragraphs>
+
+## Changes Made
+- <file>: <change>
+- <file>: <change>
+
+## Affected Components
+- <pages/modules>
+
+## Testing
+- [ ] <test 1>
+- [ ] <test 2>
+
+## Impact
+- <behavior changes, migrations, user-visible differences>
+
+## Modules Affected
+- backend/ | frontendWebsite/ | docs/
+
+## Rollback Plan
+- Revert this PR to restore previous behavior
+

--- a/.github/scripts/check_no_cjk.py
+++ b/.github/scripts/check_no_cjk.py
@@ -7,6 +7,9 @@ from pathlib import Path
 ENFORCED_DIRS = [
     Path('frontendWebsite/src'),
     Path('backend/src'),
+    Path('frontendWebsite/tests'),
+    Path('backend/tests'),
+    Path('scripts'),
 ]
 ENFORCED_EXTS = {'.ts', '.tsx', '.js', '.jsx', '.cs'}
 
@@ -35,4 +38,3 @@ if violations:
 else:
     print('✅ No CJK characters detected in enforced source directories.')
     sys.exit(0)
-

--- a/.github/scripts/check_no_cjk.py
+++ b/.github/scripts/check_no_cjk.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+import sys
+import re
+from pathlib import Path
+
+# Directories and extensions to enforce (source code only)
+ENFORCED_DIRS = [
+    Path('frontendWebsite/src'),
+    Path('backend/src'),
+]
+ENFORCED_EXTS = {'.ts', '.tsx', '.js', '.jsx', '.cs'}
+
+# CJK Unified Ideographs (basic + extensions A/B range simplified)
+CJK_REGEX = re.compile(r"[\u3400-\u4DBF\u4E00-\u9FFF\U00020000-\U0002A6DF]")
+
+violations = []
+
+for root in ENFORCED_DIRS:
+    if not root.exists():
+        continue
+    for p in root.rglob('*'):
+        if p.suffix in ENFORCED_EXTS and p.is_file():
+            try:
+                content = p.read_text(encoding='utf-8', errors='ignore')
+            except Exception:
+                continue
+            if CJK_REGEX.search(content):
+                violations.append(str(p))
+
+if violations:
+    print('❌ Found CJK characters in source files (not allowed):')
+    for v in violations:
+        print('-', v)
+    sys.exit(1)
+else:
+    print('✅ No CJK characters detected in enforced source directories.')
+    sys.exit(0)
+

--- a/.github/workflows/validate-no-cjk.yml
+++ b/.github/workflows/validate-no-cjk.yml
@@ -2,9 +2,9 @@ name: Validate No CJK In Source
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ '**' ]
   push:
-    branches: [ main ]
+    branches: [ '**' ]
 
 jobs:
   no-cjk:
@@ -16,4 +16,3 @@ jobs:
       - name: Run CJK check on source files
         run: |
           python3 .github/scripts/check_no_cjk.py
-

--- a/.github/workflows/validate-no-cjk.yml
+++ b/.github/workflows/validate-no-cjk.yml
@@ -1,0 +1,19 @@
+name: Validate No CJK In Source
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  no-cjk:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run CJK check on source files
+        run: |
+          python3 .github/scripts/check_no_cjk.py
+

--- a/claude/docs/guides/WORKFLOW_TEMPLATE_CN.md
+++ b/claude/docs/guides/WORKFLOW_TEMPLATE_CN.md
@@ -13,6 +13,11 @@
 - 无本地锁：
   - `rm -f .git/index.lock`
 
+## 流程强制第一步（中文评审与授权）
+- 每次改动前，必须先用中文向仓库所有者提交“变更分析与方案”（问题、根因、候选方案、推荐方案、影响范围、验证计划）。
+- 等待仓库所有者“中文确认 + 授权”后，方可进入后续的分支、提交、PR 等操作。
+- PR 描述中需包含“已完成中文方案确认并获授权”的说明（或勾选 PR 模板中的对应项）。
+
 ## 分支命名（规范）
 - 功能/增强：`enhancement/yuan0173/<scope>/<kebab-描述>`
 - 缺陷修复：`bugfix/yuan0173/<scope>/<kebab-描述>`
@@ -51,6 +56,7 @@
 - `chore(frontend): update development environment API base URL to Render backend`
 
 ## PR 模板（英文，纯文本，无加粗）
+- 首行须注明：`[x] 中文方案已与仓库所有者确认并获得授权`
 - Title：`<type(scope): concise description>`
 - Summary：说明修复/功能点与原因
 - Changes Made：列出文件与关键改动（每文件 1–3 点）

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Enforce English-only in source code before commit
+
+set -euo pipefail
+
+python3 .github/scripts/check_no_cjk.py
+
+echo "Pre-commit check passed: no CJK characters in source."


### PR DESCRIPTION
- CI now runs on push/PR for all branches ('**')\n- Scan extended to frontendWebsite/tests, backend/tests, scripts\n- Add scripts/githooks/pre-commit (developers can set `git config core.hooksPath scripts/githooks`)