### PR TITLE
fix(frontend): preload inactive staff for accurate initial count

### DIFF
--- a/frontendWebsite/src/pages/AdminStaffs.tsx
+++ b/frontendWebsite/src/pages/AdminStaffs.tsx
@@ -212,13 +212,13 @@ export function AdminStaffs({ currentUser }: AdminStaffsProps) {
     refetchOnWindowFocus: false,
   })
 
-  // Fetch inactive (soft-deleted) staff data from API
+  // Fetch inactive (soft-deleted) staff data from API (preload for accurate tab count)
   const { data: inactiveStaffs = [], isLoading: isLoadingInactive } = useQuery({
     queryKey: ['inactiveStaffs'],
     queryFn: () => staffApi.getInactive(),
     retry: 1,
     refetchOnWindowFocus: false,
-    enabled: activeTab === 1, // Only fetch when "Inactive Staff" tab is active
+    staleTime: 300000, // 5 minutes to avoid frequent refetching
   })
 
   // Create staff mutation


### PR DESCRIPTION
Preload inactive staff data so the Inactive tab count is correct on first render.\n\nChanges:\n- Remove `enabled: activeTab === 1` from inactiveStaffs useQuery\n- Add `staleTime: 5 minutes` to reduce unnecessary refetches\n\nImpact:\n- Accurate counts without user interaction; minimal extra cost (one preload request).\n\nTesting:\n- Initial load shows real Inactive count (e.g., 2) without switching tabs.\n- Switching tabs renders respective lists correctly.