### PR TITLE
enhancement(frontend): pre-warm backend and add login timeout UX

### DIFF
--- a/frontendWebsite/src/App.tsx
+++ b/frontendWebsite/src/App.tsx
@@ -36,6 +36,7 @@ import { AdminLoginHistory } from './pages/AdminLoginHistory'
 // Offline functionality
 import { initDB } from './offline/db'
 import { startAutoSync, stopAutoSync } from './offline/sync'
+import { httpClient } from './api/http'
 
 // Create a client
 const queryClient = new QueryClient({
@@ -96,6 +97,14 @@ function App() {
 
         window.addEventListener('online', handleOnline)
         window.addEventListener('offline', handleOffline)
+
+        // Pre-warm backend to reduce first-login latency
+        try {
+          await httpClient.get('/health', { timeout: 5000 })
+        } catch (err) {
+          // Ignore pre-warm errors; backend may still be starting
+          console.warn('Backend pre-warm failed (will not block app):', err)
+        }
 
         // User state is automatically loaded from localStorage via Zustand persist
         setLoading(false)

--- a/frontendWebsite/src/api/client.ts
+++ b/frontendWebsite/src/api/client.ts
@@ -164,11 +164,12 @@ export const staffApi = {
 
 // Auth API
 export const authApi = {
-  login: async (email: string, password: string) => {
-    const response = await httpClient.post('/api/Auth/login', {
-      email,
-      password
-    })
+  login: async (email: string, password: string, options?: { timeout?: number }) => {
+    const response = await httpClient.post(
+      '/api/Auth/login',
+      { email, password },
+      { timeout: options?.timeout ?? 10000 }
+    )
     return response.data
   },
 

--- a/frontendWebsite/src/pages/Login.tsx
+++ b/frontendWebsite/src/pages/Login.tsx
@@ -54,8 +54,8 @@ export function Login({ onLogin }: LoginProps) {
         return
       }
 
-      // Use the proper authentication API
-      const loginResponse = await authApi.login(email, password)
+      // Use the proper authentication API with a dedicated timeout
+      const loginResponse = await authApi.login(email, password, { timeout: 8000 })
       
       if (loginResponse && loginResponse.staff) {
         const currentUser: CurrentUser = {
@@ -89,9 +89,17 @@ export function Login({ onLogin }: LoginProps) {
       } else {
         throw new Error('Invalid login response')
       }
-    } catch (error) {
+    } catch (error: any) {
       console.error('Login error:', error)
-      setError('Invalid email or password. Please try again.')
+      // Friendly messages for timeout / network / auth
+      const message = typeof error === 'string' ? error : error?.message || ''
+      if (message.toLowerCase().includes('timeout')) {
+        setError('Server is waking up. Please try again in a few seconds.')
+      } else if (message.toLowerCase().includes('network')) {
+        setError('Network issue detected. Please check your connection and try again.')
+      } else {
+        setError('Invalid email or password. Please try again.')
+      }
     } finally {
       setIsLoading(false)
     }


### PR DESCRIPTION
- Call /health on app startup to reduce first-login delay (Render cold start)\n- authApi.login now supports per-call timeout; Login uses 8s and shows friendly messages for timeout/network errors\n- No backend changes; UI remains the same aside from improved feedback