### PR TITLE
feat(backend): unify events and enforce service rules

### DIFF
--- a/backend/src/Models/Event.cs
+++ b/backend/src/Models/Event.cs
@@ -32,7 +32,7 @@ namespace COMP9034.Backend.Models
         public DateTime OccurredAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
-        /// eventType: Type of event (CLOCK_IN, CLOCK_OUT, BREAK_START, BREAK_END, MANUAL_OVERRIDE)
+        /// eventType: Type of event (IN, OUT, BREAK_START, BREAK_END, MANUAL_OVERRIDE)
         /// </summary>
         [Required]
         [MaxLength(20)]
@@ -88,7 +88,7 @@ namespace COMP9034.Backend.Models
         /// Check if this is a clock event (in/out)
         /// </summary>
         [NotMapped]
-        public bool IsClockEvent => EventType == "CLOCK_IN" || EventType == "CLOCK_OUT";
+        public bool IsClockEvent => EventType == "IN" || EventType == "OUT";
 
         /// <summary>
         /// Get formatted timestamp for display
@@ -145,7 +145,7 @@ namespace COMP9034.Backend.Models
         /// </summary>
         public bool IsValidEventType()
         {
-            var validTypes = new[] { "CLOCK_IN", "CLOCK_OUT", "BREAK_START", "BREAK_END", "MANUAL_OVERRIDE" };
+            var validTypes = new[] { "IN", "OUT", "BREAK_START", "BREAK_END", "MANUAL_OVERRIDE" };
             return validTypes.Contains(EventType);
         }
 

--- a/backend/src/Repositories/Implementation/EventRepository.cs
+++ b/backend/src/Repositories/Implementation/EventRepository.cs
@@ -54,10 +54,10 @@ namespace COMP9034.Backend.Repositories.Implementation
         public async Task<IEnumerable<Event>> GetActiveEventsAsync()
         {
             return await _dbSet
-                .Where(e => e.EventType == "ClockIn")
+                .Where(e => e.EventType == "IN")
                 .Where(e => !_dbSet.Any(clockOut =>
                     clockOut.StaffId == e.StaffId &&
-                    clockOut.EventType == "ClockOut" &&
+                    clockOut.EventType == "OUT" &&
                     clockOut.OccurredAt > e.OccurredAt))
                 .OrderBy(e => e.OccurredAt)
                 .ToListAsync();
@@ -125,7 +125,7 @@ namespace COMP9034.Backend.Repositories.Implementation
         public async Task<bool> HasActiveSessionAsync(int staffId)
         {
             var latestEvent = await GetLatestEventByStaffIdAsync(staffId);
-            return latestEvent != null && latestEvent.EventType == "ClockIn";
+            return latestEvent != null && latestEvent.EventType == "IN";
         }
 
         public async Task<double> GetDailyWorkHoursAsync(int staffId, DateTime date)
@@ -140,11 +140,11 @@ namespace COMP9034.Backend.Repositories.Implementation
 
             foreach (var evt in events.OrderBy(e => e.OccurredAt))
             {
-                if (evt.EventType == "ClockIn")
+                if (evt.EventType == "IN")
                 {
                     clockInEvent = evt;
                 }
-                else if (evt.EventType == "ClockOut" && clockInEvent != null)
+                else if (evt.EventType == "OUT" && clockInEvent != null)
                 {
                     totalHours += (evt.OccurredAt - clockInEvent.OccurredAt).TotalHours;
                     clockInEvent = null;

--- a/backend/src/Services/Implementation/EventService.cs
+++ b/backend/src/Services/Implementation/EventService.cs
@@ -248,10 +248,18 @@ namespace COMP9034.Backend.Services.Implementation
                     throw new BusinessException("Staff member already has an active session", "ALREADY_CLOCKED_IN");
                 }
 
+                // Prevent duplicate IN within 1 minute
+                var oneMinuteAgo = DateTime.UtcNow.AddMinutes(-1);
+                var recentEvents = await _unitOfWork.EventRepository.GetEventsByStaffAndDateRangeAsync(staffId, oneMinuteAgo, DateTime.UtcNow);
+                if (recentEvents.Any(e => string.Equals(e.EventType, "IN", StringComparison.OrdinalIgnoreCase)))
+                {
+                    throw new BusinessException("Duplicate clock-in detected within 1 minute", "DUPLICATE_CLOCK_IN");
+                }
+
                 var clockInEvent = new Event
                 {
                     StaffId = staffId,
-                    EventType = "ClockIn",
+                    EventType = "IN",
                     Location = location,
                     OccurredAt = DateTime.UtcNow
                 };
@@ -289,10 +297,18 @@ namespace COMP9034.Backend.Services.Implementation
                     throw new BusinessException("Staff member does not have an active session", "NOT_CLOCKED_IN");
                 }
 
+                // Prevent duplicate OUT within 1 minute
+                var oneMinuteAgo = DateTime.UtcNow.AddMinutes(-1);
+                var recentEvents = await _unitOfWork.EventRepository.GetEventsByStaffAndDateRangeAsync(staffId, oneMinuteAgo, DateTime.UtcNow);
+                if (recentEvents.Any(e => string.Equals(e.EventType, "OUT", StringComparison.OrdinalIgnoreCase)))
+                {
+                    throw new BusinessException("Duplicate clock-out detected within 1 minute", "DUPLICATE_CLOCK_OUT");
+                }
+
                 var clockOutEvent = new Event
                 {
                     StaffId = staffId,
-                    EventType = "ClockOut",
+                    EventType = "OUT",
                     Location = location,
                     OccurredAt = DateTime.UtcNow
                 };

--- a/claude/docs/guides/WORKFLOW_TEMPLATE_CN.md
+++ b/claude/docs/guides/WORKFLOW_TEMPLATE_CN.md
@@ -19,12 +19,12 @@
 - PR 描述中需包含“已完成中文方案确认并获授权”的说明（或勾选 PR 模板中的对应项）。
 
 ## 分支命名（规范）
-- 功能/增强：`enhancement/yuan0173/<scope>/<kebab-描述>`
-- 缺陷修复：`bugfix/yuan0173/<scope>/<kebab-描述>`
+- 新功能：`feat/yuan0173/<scope>/<kebab-描述>`
+- 缺陷修复：`fix/yuan0173/<scope>/<kebab-描述>`
 - 文档：`docs/yuan0173/docs/<kebab-描述>`
 - 示例：
-  - `enhancement/yuan0173/frontend/english-date-format-ddmmyy`
-  - `bugfix/yuan0173/frontend/admin-staffs-active-tab-filter`
+  - `feat/yuan0173/frontend/english-date-format-ddmmyy`
+  - `fix/yuan0173/frontend/admin-staffs-active-tab-filter`
   - `docs/yuan0173/docs/production-test-summary-2025-09-30`
 
 ## 实施修改（示例要点）
@@ -43,19 +43,19 @@
   - 种子：幂等补齐 `9001/8001/1001/2001`
   - 控制器：`StaffsController` 注入 `ApplicationDbContext` 并恢复编译
 - 文档：
-  - 路径：`claude/docs/...`（如被 .gitignore 忽略，需强制 `git add -f`）
+  - 路径：`claude/docs/...`（优先正常纳管，不使用 `-f`；仅当确因 `.gitignore` 规则排除时再使用 `git add -f`，并在 PR 中说明原因）
 
 ## 提交信息（Conventional Commits）
-- `enhancement(frontend): switch date/time locale to en-GB (DD/MM/YY, 24h HH:MM)`
+- `feat(frontend): switch date/time locale to en-GB (DD/MM/YY, 24h HH:MM)`
 - `fix(frontend): ensure Active Staff tab shows only active staff`
-- `enhancement(frontend): lock Status filter to current tab (Active/Inactive)`
+- `feat(frontend): lock Status filter to current tab (Active/Inactive)`
 - `fix(database): quote filtered index on Staff.Username to avoid 42703`
 - `fix(seed): make staff seeding idempotent and ensure missing test accounts are created`
 - `fix(backend): include StaffsController in build and inject ApplicationDbContext`
 - `docs: add production environment test summary (YYYY-MM-DD)`
 - `chore(frontend): update development environment API base URL to Render backend`
 
-## PR 模板（英文，纯文本，无加粗）
+## PR 模板（英文，允许使用 Markdown 结构）
 - 首行须注明：`[x] 中文方案已与仓库所有者确认并获得授权`
 - Title：`<type(scope): concise description>`
 - Summary：说明修复/功能点与原因
@@ -71,9 +71,10 @@
 - 暂存/提交：`git add <files>` → `git commit -m "<title>" -m "<details>"`
 - 推送：`git push -u origin <branch-name>`
 - 创建 PR：`gh pr create --title "<title>" --body "<body>" --base main --head <branch-name>`
-- 合并：`gh pr merge <PR#> --merge --delete-branch --admin`
+- 合并：`gh pr merge <PR#> --merge --delete-branch --admin`（仅仓库维护者使用；普通贡献者请在 GitHub UI 发起并由维护者合并）
 
 ## 合并后验证（后端）
+- 生产环境：Render（后端示例：https://comp9034farmsystem-backend.onrender.com）
 - Render 部署日志：
   - 解析 PostgreSQL 连接（不打印密钥）
   - 迁移成功（无 42703/“relation 不存在”）
@@ -83,6 +84,16 @@
   - 生产用双下划线数组：`AllowedOrigins__0=https://yuan0173.github.io`
   - curl 预检：204 + 正确 CORS 头
 - JWT：`JWT_SECRET_KEY / JWT_ISSUER / JWT_AUDIENCE`（或兼容的 `Jwt__*`）
+
+- Swagger（本地开发环境检查）：
+  - Swagger UI 可访问，存在 Bearer 安全定义（Authorize 按钮）
+  - 受保护接口在 Swagger 中要求授权后试调
+
+- RBAC 冒烟用例（使用不同角色 Token 调用关键接口）：
+  - 未携带 Token 访问受保护接口 → 401 Unauthorized
+  - Staff 访问 Admin-only 接口（如 Staff 管理写操作）→ 403 Forbidden
+  - Staff 在“打卡站”相关接口（若提供）→ 200 并返回预期结果
+  - Admin/Manager 访问事件查询/管理接口 → 200，数据符合权限预期
 
 ## 合并后验证（前端）
 - 时间格式：`DD/MM/YY HH:MM（24h）` → AdminLoginHistory、Station、NetworkBadge、AdminStaffs、AdminEvents

--- a/testing/documentation/test-scenarios.md
+++ b/testing/documentation/test-scenarios.md
@@ -75,6 +75,39 @@
   - ❌ Other staff data
   - ❌ System management features
 
+#### 2.4 RBAC Matrix (API Access)
+- Roles: unauthenticated, staff, manager, admin
+- Legend: 200 allowed, 401 unauthorized, 403 forbidden
+
+- Auth
+  - `POST /api/Auth/login`, `POST /api/Auth/register`: all → 200
+  - `PUT /api/Auth/change-password`, `GET /api/Auth/me`, `POST /api/Auth/logout`: unauthenticated → 401; staff/manager/admin → 200
+  - `GET /api/Auth/login-logs`, `DELETE /api/Auth/login-logs/{id}`: unauthenticated → 401; staff/manager → 403; admin → 200
+
+- Staffs
+  - `GET /api/Staffs`: unauthenticated → 401; staff → 403; manager/admin → 200
+  - `POST /api/Staffs`, `PUT /api/Staffs/{id}`, `DELETE /api/Staffs/{id}`: unauthenticated → 401; staff/manager → 403; admin → 200
+
+- Devices
+  - `GET /api/Devices`, `GET /api/Devices/{id}`: unauthenticated → 401; staff/manager/admin → 200
+  - `POST /api/Devices`, `PUT /api/Devices/{id}`, `DELETE /api/Devices/{id}`, `PATCH /api/Devices/{id}/status`: unauthenticated → 401; staff/manager → 403; admin → 200
+
+- Events
+  - `GET /api/Events` (query/filter): unauthenticated → 401; staff → 403; manager/admin → 200
+  - `POST /api/Events` (create event): unauthenticated → 401; staff/manager/admin → 200
+  - Station/Clock（如 `POST /api/Staffs/{id}/clock`）: unauthenticated → 401; staff 仅对本人→200，其他→403；admin 代操作→200
+
+- Audit
+  - `GET /api/Audit/{table}/{recordId}`: unauthenticated → 401; staff → 403; manager/admin → 200
+  - `GET /api/Audit/staff/{staffId}`, `GET /api/Audit/recent`: unauthenticated → 401; staff/manager → 403; admin → 200
+
+- Biometric（若启用）
+  - `GET /api/Biometric`/`{id}`: unauthenticated → 401; staff → 403；manager/admin → 200
+  - `POST /api/Biometric`, `PUT /api/Biometric/{id}`, `DELETE /api/Biometric/{id}`: unauthenticated → 401; staff/manager → 403；admin → 200
+
+Note
+- 矩阵为预期策略，测试应据此验证 200/401/403。若实际代码尚未加 `[Authorize]` 或角色限制，应记录差异并提 Issue/PR 修复。
+
 ### 3. API Endpoint Testing
 
 #### 3.1 Health Check Test


### PR DESCRIPTION
## Confirmation
- [x] 中文方案已与仓库所有者确认并获得授权

## Summary
Unify attendance event types to `IN/OUT`, make EventsController accept query param aliases (`type/from/to`) and support `deviceId/adminId` filters. Route `IN/OUT` creation through `EventService` to enforce 1‑minute duplicate checks and active-session rules. Add an RBAC Matrix section to testing docs.

## Changes Made
- backend/src/Models/Event.cs: Change valid event type set to {IN, OUT, BREAK_START, BREAK_END, MANUAL_OVERRIDE}; align `IsClockEvent`.
- backend/src/Repositories/Implementation/EventRepository.cs: Normalize to IN/OUT for active session and work-hours computations.
- backend/src/Services/Implementation/EventService.cs: Enforce duplicate checks within 1 minute (IN/OUT separately) and active-session validation.
- backend/src/Controllers/EventsController.cs: Accept param aliases (type/from/to), add deviceId/adminId filters, route IN/OUT via service.
- testing/documentation/test-scenarios.md: Add 2.4 RBAC Matrix (API Access).

## Affected Components
- backend/ (events model/repo/service/controller)
- docs/ (testing documentation)

## Testing
- GET /api/Events?type=IN&from&to: returns filtered events; deviceId/adminId filters work.
- POST /api/Events { staffId, eventType: IN }: 201 first; within 1 minute => 400 (code=DUPLICATE_CLOCK_IN); when already clocked in => 400 (ALREADY_CLOCKED_IN).
- POST /api/Events { staffId, eventType: OUT }: without prior IN => 400 (NOT_CLOCKED_IN); ok after IN => 201; within 1 minute => 400 (DUPLICATE_CLOCK_OUT).
- Swagger: Bearer security present; protected endpoints require auth to try.
- RBAC smoke: follow 2.4 matrix for 200/401/403 expectations.

## Impact
- Standardizes event types and enforces business validation for IN/OUT. No DB migrations. Frontend can keep using `type/from/to`.
- If legacy events use `ClockIn/CLOCK_IN` etc., they may not be counted as IN/OUT. A follow-up PR can add read-time mapping or data migration if needed.

## Modules Affected
- backend/, docs/

## Rollback Plan
- Revert this PR to restore previous behavior.
