### PR TITLE
feat(frontend): AdminRoster Autocomplete; feat(api): staff search alias

### DIFF
--- a/backend/src/Controllers/StaffsController.cs
+++ b/backend/src/Controllers/StaffsController.cs
@@ -47,6 +47,12 @@ namespace COMP9034.Backend.Controllers
         {
             try
             {
+                // Accept alias: query -> search (frontend compatibility)
+                if (string.IsNullOrWhiteSpace(search))
+                {
+                    var alias = Request.Query["query"].FirstOrDefault();
+                    if (!string.IsNullOrWhiteSpace(alias)) search = alias;
+                }
                 // Convert offset-based pagination to page-based
                 int pageNumber = (offset / (limit ?? 50)) + 1;
                 int pageSize = limit ?? 50;

--- a/frontendWebsite/src/api/client.ts
+++ b/frontendWebsite/src/api/client.ts
@@ -1,5 +1,5 @@
 import { httpClient } from './http'
-import {
+import { 
   BiometricData,
   BiometricQuery,
   Device,
@@ -159,8 +159,14 @@ export const loginHistoryApi = {
 export const staffApi = {
   getAll: async (query?: StaffQuery): Promise<Staff[]> => {
     const params = new URLSearchParams()
-    if (query?.query) params.append('query', query.query)
+    if (query?.query) params.append('query', query.query) // alias accepted by backend
     
+    const response = await httpClient.get(`/api/Staffs?${params.toString()}`)
+    return response.data
+  },
+  search: async (term: string): Promise<Staff[]> => {
+    const params = new URLSearchParams()
+    params.append('query', term)
     const response = await httpClient.get(`/api/Staffs?${params.toString()}`)
     return response.data
   },


### PR DESCRIPTION
  Summary
  The current Admin Roster form asks admins to manually type a Staff ID, which is
  error‑prone (Staff not found) and increases cognitive load. This PR replaces the
  Staff ID textbox with an Autocomplete that searches by name/email/ID with a debounce.
  To ensure compatibility, the backend StaffsController now accepts query as an alias
  for search. The goal is to reduce input errors and speed up roster creation without
  changing business rules.

  Changes Made

  - frontendWebsite/src/pages/AdminRoster.tsx
      - Replace Staff ID TextField with MUI Autocomplete (type name/email/ID)
      - 300 ms debounce for search; keyboard navigation supported
      - Displays options as “FirstName LastName (staffId) – email”
      - Selecting an option fills the form’s staffId
  - frontendWebsite/src/api/client.ts
      - Add staffApi.search(term) → GET /api/Staffs?query=term
      - Reuse existing Staffs endpoint for lightweight search
  - backend/src/Controllers/StaffsController.cs
      - Accept alias query → search for compatibility with frontend

  Affected Components

  - frontendWebsite: AdminRoster page, API client
  - backend: StaffsController (query alias only)

  Testing

  - Autocomplete
      - In Admin Roster dialog, type “jo”: list shows matching staff by name/email/ID
      - Navigate options with keyboard; on select, staffId is populated
  - Create/Update Roster
      - Create with valid date/time → 201 Created
      - Overlapping shift on the same day → 400 with error message
      - Invalid/empty form fields → error message shown
  - Regression
      - Existing roster operations continue to work
      - No database schema changes; no migrations required

  Impact

  - User‑visible improvement: faster and safer staff selection, fewer “Staff not found”
  errors
  - Backend change is minimal (query alias only); no behavior or auth changes
  - No DB changes; no migration; no ops impact

  Modules Affected

  - backend/
  - frontendWebsite/

  Rollback Plan

  - Revert this PR to restore the previous textbox‑based input.