### PR TITLE
feat(frontend): AdminRoster Autocomplete; improve UX (active-only, stable open,   clearer option layout)

### DIFF
--- a/backend/src/Controllers/StaffsController.cs
+++ b/backend/src/Controllers/StaffsController.cs
@@ -43,7 +43,8 @@ namespace COMP9034.Backend.Controllers
             [FromQuery] int? limit = null,
             [FromQuery] int offset = 0,
             [FromQuery] string? search = null,
-            [FromQuery] string? role = null)
+            [FromQuery] string? role = null,
+            [FromQuery] bool? isActive = null)
         {
             try
             {
@@ -53,11 +54,28 @@ namespace COMP9034.Backend.Controllers
                     var alias = Request.Query["query"].FirstOrDefault();
                     if (!string.IsNullOrWhiteSpace(alias)) search = alias;
                 }
+                // Accept alias: activeOnly -> isActive=true
+                if (!isActive.HasValue)
+                {
+                    var activeOnly = Request.Query["activeOnly"].FirstOrDefault();
+                    if (!string.IsNullOrWhiteSpace(activeOnly) && bool.TryParse(activeOnly, out var ao) && ao)
+                    {
+                        isActive = true;
+                    }
+                    else
+                    {
+                        var isActiveStr = Request.Query["isActive"].FirstOrDefault();
+                        if (!string.IsNullOrWhiteSpace(isActiveStr) && bool.TryParse(isActiveStr, out var ia))
+                        {
+                            isActive = ia;
+                        }
+                    }
+                }
                 // Convert offset-based pagination to page-based
                 int pageNumber = (offset / (limit ?? 50)) + 1;
                 int pageSize = limit ?? 50;
 
-                var result = await _staffService.GetStaffPagedAsync(pageNumber, pageSize, search, role, null);
+                var result = await _staffService.GetStaffPagedAsync(pageNumber, pageSize, search, role, isActive);
 
                 if (result.Success)
                 {

--- a/frontendWebsite/src/api/client.ts
+++ b/frontendWebsite/src/api/client.ts
@@ -160,13 +160,19 @@ export const staffApi = {
   getAll: async (query?: StaffQuery): Promise<Staff[]> => {
     const params = new URLSearchParams()
     if (query?.query) params.append('query', query.query) // alias accepted by backend
+    if (typeof query?.isActive === 'boolean') params.append('isActive', String(query.isActive))
+    if (typeof query?.limit === 'number') params.append('limit', String(query.limit))
+    if (typeof query?.offset === 'number') params.append('offset', String(query.offset))
     
     const response = await httpClient.get(`/api/Staffs?${params.toString()}`)
     return response.data
   },
-  search: async (term: string): Promise<Staff[]> => {
+  search: async (term: string, opts?: { activeOnly?: boolean; limit?: number; offset?: number }): Promise<Staff[]> => {
     const params = new URLSearchParams()
     params.append('query', term)
+    if (opts?.activeOnly) params.append('isActive', 'true')
+    if (typeof opts?.limit === 'number') params.append('limit', String(opts.limit))
+    if (typeof opts?.offset === 'number') params.append('offset', String(opts.offset))
     const response = await httpClient.get(`/api/Staffs?${params.toString()}`)
     return response.data
   },

--- a/frontendWebsite/src/types/api.ts
+++ b/frontendWebsite/src/types/api.ts
@@ -94,6 +94,9 @@ export interface EventQuery {
 
 export interface StaffQuery {
   query?: string
+  isActive?: boolean
+  limit?: number
+  offset?: number
 }
 
 // Staff creation request interface (matches backend StaffCreateRequest)


### PR DESCRIPTION
Confirmation

  - [x] Authorized offline; repository content is English-only.

  Summary
  The Admin Roster dialog previously required typing a Staff ID, which is error-
  prone and increases cognitive load. This PR replaces the Staff ID textbox with a
  debounced Autocomplete that searches by name/email/ID and shows a clearer two-line
  option layout. The list loads active staff on open to stabilize the dropdown. For
  compatibility, the backend StaffsController now accepts isActive/query aliases so the
  frontend can request active-only lists.

  BA Spec Checklist (FR/AC)

  - F3-FR1 / F3-AC1 (Assign shift date/start/end): Supported by improving staff
  selection UX (no rule change).
  - F3-FR2 / F3-AC2 (Auto-calc hours): Unchanged.
  - F3-FR3 / F3-AC3 (Prevent overlap): Unchanged.
  - F3-FR4 / F3-AC4 (Audit roster changes): Unchanged.
  Note: This PR focuses on UX; roster business rules remain enforced on the backend.

  Changes Made

  - frontendWebsite/src/pages/AdminRoster.tsx
      - Replace Staff ID TextField with MUI Autocomplete (search by name/email/ID; 300
  ms debounce).
      - React Query v5: use placeholderData: keepPreviousData to keep prior results
  during fetch.
      - Render options on two lines (name on top; “ID • email • ✓ Active” below).
      - Load an initial active staff list when the dialog opens to stabilize dropdown
  behavior.
  - frontendWebsite/src/api/client.ts
      - Add staffApi.search(term, { activeOnly, limit, offset }).
      - Extend staffApi.getAll to support isActive/limit/offset.
  - frontendWebsite/src/types/api.ts
      - Extend StaffQuery with isActive/limit/offset.
  - backend/src/Controllers/StaffsController.cs
      - Accept aliases: query → search, activeOnly → isActive=true; pass isActive to
  service layer.

  Affected Components

  - frontendWebsite: Admin Roster dialog and API client.
  - backend: StaffsController (parameter alias handling only).

  Testing

  - Autocomplete behavior
      - Open “New Shift” → initial list shows active staff (no input).
      - Type “jo” → options show matching active staff by name/email/ID.
      - Keyboard navigate; on select, form.staffId is populated.
  - Roster operations
      - Create valid shift → 201 Created.
      - Create overlapping same-day shift → 400 with backend validation message.
  - Regression
      - No schema/migration changes; other UI flows unaffected.

  Impact

  - User-visible improvement: faster and safer staff selection; fewer “Staff not found”
  errors.
  - Backend change is minimal (query/isActive aliases); no auth or business-rule
  changes.
  - No database migrations; no operational changes required.

  Rollback Plan

  - Revert this PR to restore previous textbox-based input.